### PR TITLE
Support docker for dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ruby:2.3.0
+
+# The soures.list was outdated
+RUN echo "deb http://httpredir.debian.org/debian jessie main\n\
+deb http://security.debian.org jessie/updates main" \
+> /etc/apt/sources.list
+
+# lsof is required by guard
+RUN apt-get update && apt-get install -y lsof
+
+RUN mkdir /myapp
+WORKDIR /myapp
+COPY Gemfile /myapp/Gemfile
+COPY Gemfile.lock /myapp/Gemfile.lock
+RUN bundle install
+COPY . /myapp
+
+EXPOSE 9292
+
+# Turn notification off because
+# the docker image does not have libnotify
+CMD ["bundle", "exec", "guard", "-n", "f"]

--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ To start the server run `bundle exec guard`, and then view the awesome at `local
 
 To run the tests: `bundle exec rspec`
 
+*(Optional)* To quickly launch the dev server without having to install the dependencies:
+```
+docker-compose up --build
+```
+
 ## Fetch some talks
 
 To test out the API, you will need to populate your database by running the spiders: `bundle exec rake crawl` will iterate through all of them.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.7"
+services:
+  api:
+    build: .
+    tty: true
+    volumes:
+      - ./:/myapp
+    ports:
+      - "9292:9292"
+  mongo:
+    image: mongo:3.4.21
+    ports:
+      - "27017:27017"


### PR DESCRIPTION
As a developer I would like to use docker to quickly launch the dev environment so that I don't have to install all the dependencies i.e ruby, mongo,... on my machine.


![dharma-api-docker](https://user-images.githubusercontent.com/28383668/59734524-9ba12880-9206-11e9-9e02-c25e38073aa0.gif)
